### PR TITLE
Bugfix for RMLNQ-54: Processing of member initialization expressions fails if the member is declared on a sub-class

### DIFF
--- a/Core/Clauses/ExpressionTreeVisitors/AccessorFindingExpressionTreeVisitor.cs
+++ b/Core/Clauses/ExpressionTreeVisitors/AccessorFindingExpressionTreeVisitor.cs
@@ -65,7 +65,7 @@ namespace Remotion.Linq.Clauses.ExpressionTreeVisitors
       if (inputParameter.Type != fullExpression.Type)
       {
         throw new ArgumentException (
-            string.Format ("The inputParameter's type '{0}' must match the fullExpression's type '{1}'.", fullExpression.Type, inputParameter.Type),
+            string.Format ("The inputParameter's type '{0}' must match the fullExpression's type '{1}'.", inputParameter.Type, fullExpression.Type),
             "inputParameter");
       }
 

--- a/UnitTests/Clauses/ExpressionTreeVisitors/AccessorFindingExpressionTreeVisitorTest.cs
+++ b/UnitTests/Clauses/ExpressionTreeVisitors/AccessorFindingExpressionTreeVisitorTest.cs
@@ -119,8 +119,8 @@ namespace Remotion.Linq.UnitTests.Clauses.ExpressionTreeVisitors
 
       var inputParameter = Expression.Parameter (typeof (AnonymousType), "input");
       var expectedResult = Expression.Lambda (
-
-      Expression.MakeMemberAccess (inputParameter, _anonymousTypeAProperty), inputParameter);
+          Expression.MakeMemberAccess (inputParameter, _anonymousTypeAProperty),
+          inputParameter);
       ExpressionTreeComparer.CheckAreEqualTrees (expectedResult, result);
     }
 
@@ -160,9 +160,10 @@ namespace Remotion.Linq.UnitTests.Clauses.ExpressionTreeVisitors
       var result = AccessorFindingExpressionTreeVisitor.FindAccessorLambda (_searchedExpression, fullExpression, _nestedInputParameter);
 
       var inputParameter = Expression.Parameter (typeof (AnonymousType<int, AnonymousType>), "input");
+       // input => input.get_b().get_a()
       var expectedResult = Expression.Lambda (
-      Expression.MakeMemberAccess (Expression.MakeMemberAccess (inputParameter, outerAnonymousTypeBProperty), _anonymousTypeAProperty),
-      inputParameter);  // input => input.get_b().get_a()
+          Expression.MakeMemberAccess (Expression.MakeMemberAccess (inputParameter, outerAnonymousTypeBProperty), _anonymousTypeAProperty),
+          inputParameter);
 
       ExpressionTreeComparer.CheckAreEqualTrees (expectedResult, result);
     }

--- a/UnitTests/Clauses/ExpressionTreeVisitors/IntegrationTests/AccessorFindingExpressionTreeVisitorIntegrationTest.cs
+++ b/UnitTests/Clauses/ExpressionTreeVisitors/IntegrationTests/AccessorFindingExpressionTreeVisitorIntegrationTest.cs
@@ -1,0 +1,115 @@
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+//
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.  rubicon licenses this file to you under 
+// the Apache License, Version 2.0 (the "License"); you may not use this 
+// file except in compliance with the License.  You may obtain a copy of the 
+// License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the 
+// License for the specific language governing permissions and limitations
+// under the License.
+// 
+
+using System;
+using System.Linq;
+using System.Linq.Expressions;
+using NUnit.Framework;
+using Remotion.Linq.Clauses.ExpressionTreeVisitors;
+using Remotion.Linq.Development.UnitTesting;
+using Remotion.Linq.UnitTests.TestDomain;
+
+namespace Remotion.Linq.UnitTests.Clauses.ExpressionTreeVisitors.IntegrationTests
+{
+  [TestFixture]
+  public class AccessorFindingExpressionTreeVisitorIntegrationTest
+  {
+    [Test]
+    public void NewExpressionForAnonymousType()
+    {
+      Expression<Func<Cook, dynamic>> lambaExpression = c => new { OuterValue = new { InnerValue = c.FirstName } };
+
+      // new OuterType (...)
+      var resultInitExpression = ((NewExpression) lambaExpression.Body);
+      // new InnerType (...)
+      var derivedValueInitExpression = (NewExpression) resultInitExpression.Arguments[0];
+      // c.FirstName
+      var derivedValueStringValuePropertyExpression = (MemberExpression) derivedValueInitExpression.Arguments[0];
+
+      var inputParameter = Expression.Parameter (resultInitExpression.Type, "input");
+
+      var result = AccessorFindingExpressionTreeVisitor.FindAccessorLambda (
+          searchedExpression: derivedValueStringValuePropertyExpression,
+          fullExpression: resultInitExpression,
+          inputParameter: inputParameter);
+
+      // Expression<Func<dynamic, string>> input => input.OuterValue.InnerValue;
+      var expectedParameter = Expression.Parameter (resultInitExpression.Type, "input");
+      var expectedOuterProperty = Expression.Property (expectedParameter, "OuterValue");
+      var expectedInnerProperty = Expression.Property (expectedOuterProperty, "InnerValue");
+      var expectedResult = Expression.Lambda (expectedInnerProperty, expectedParameter);
+
+      ExpressionTreeComparer.CheckAreEqualTrees (expectedResult, result);
+    }
+
+    [Test]
+    public void MemberInitExpression ()
+    {
+      Expression<Func<Cook, Result<DerivedValue>>> lambaExpression =
+          c => new Result<DerivedValue> { Value = new DerivedValue { StringValue = c.FirstName } };
+
+      // new Result { ... }
+      var resultInitExpression = ((MemberInitExpression) lambaExpression.Body);
+      // BaseValue = new DerivedValue { ... }
+      var derivedValueMemberAssignment = ((MemberAssignment) resultInitExpression.Bindings[0]);
+      // new DerivedValue { ... }
+      var derivedValueInitExpression = (MemberInitExpression) (derivedValueMemberAssignment.Expression);
+      // StringValue = c.FirstName
+      var derivedValueStringValueMemberAssignment = ((MemberAssignment) derivedValueInitExpression.Bindings[0]);
+      // c.FirstName
+      var derivedValueStringValuePropertyExpression = (MemberExpression) derivedValueStringValueMemberAssignment.Expression;
+
+      var inputParameter = Expression.Parameter (typeof (Result<DerivedValue>), "input");
+
+      var result = AccessorFindingExpressionTreeVisitor.FindAccessorLambda (
+          searchedExpression: derivedValueStringValuePropertyExpression,
+          fullExpression: resultInitExpression,
+          inputParameter: inputParameter);
+
+      Expression<Func<Result<DerivedValue>, string>> expectedResult = input => input.Value.StringValue;
+      ExpressionTreeComparer.CheckAreEqualTrees (expectedResult, result);
+    }
+
+    [Test]
+    public void MemberInitExpressionForDerivedTypeCanBeUsedWithPropertyTypedAsBaseType ()
+    {
+      Expression<Func<Cook, Result<BaseValue>>> lambaExpression =
+          c => new Result<BaseValue> { Value = new DerivedValue { StringValue = c.FirstName } };
+
+      // new Result { ... }
+      var resultInitExpression = ((MemberInitExpression) lambaExpression.Body);
+      // BaseValue = new DerivedValue { ... }
+      var derivedValueMemberAssignment = ((MemberAssignment) resultInitExpression.Bindings[0]);
+      // new DerivedValue { ... }
+      var derivedValueInitExpression = (MemberInitExpression) (derivedValueMemberAssignment.Expression);
+      // StringValue = c.FirstName
+      var derivedValueStringValueMemberAssignment = ((MemberAssignment) derivedValueInitExpression.Bindings[0]);
+      // c.FirstName
+      var derivedValueStringValuePropertyExpression = (MemberExpression) derivedValueStringValueMemberAssignment.Expression;
+
+      var inputParameter = Expression.Parameter (typeof (Result<BaseValue>), "input");
+
+      var result = AccessorFindingExpressionTreeVisitor.FindAccessorLambda (
+          searchedExpression: derivedValueStringValuePropertyExpression,
+          fullExpression: resultInitExpression,
+          inputParameter: inputParameter);
+
+      Expression<Func<Result<BaseValue>, string>> expectedResult = input => ((DerivedValue) input.Value).StringValue;
+      ExpressionTreeComparer.CheckAreEqualTrees (expectedResult, result);
+    }
+  }
+}

--- a/UnitTests/TestDomain/BaseValue.cs
+++ b/UnitTests/TestDomain/BaseValue.cs
@@ -1,0 +1,24 @@
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+//
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.  rubicon licenses this file to you under 
+// the Apache License, Version 2.0 (the "License"); you may not use this 
+// file except in compliance with the License.  You may obtain a copy of the 
+// License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the 
+// License for the specific language governing permissions and limitations
+// under the License.
+// 
+using System;
+
+namespace Remotion.Linq.UnitTests.TestDomain
+{
+  public abstract class BaseValue
+  {
+  }
+}

--- a/UnitTests/TestDomain/DerivedValue.cs
+++ b/UnitTests/TestDomain/DerivedValue.cs
@@ -1,0 +1,30 @@
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+//
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.  rubicon licenses this file to you under 
+// the Apache License, Version 2.0 (the "License"); you may not use this 
+// file except in compliance with the License.  You may obtain a copy of the 
+// License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the 
+// License for the specific language governing permissions and limitations
+// under the License.
+// 
+using System;
+
+namespace Remotion.Linq.UnitTests.TestDomain
+{
+  public class DerivedValue : BaseValue
+  {
+    public DerivedValue ()
+    {
+    
+    }
+
+    public string StringValue { get; set; }
+  }
+}

--- a/UnitTests/TestDomain/Result.cs
+++ b/UnitTests/TestDomain/Result.cs
@@ -1,0 +1,29 @@
+// Copyright (c) rubicon IT GmbH, www.rubicon.eu
+//
+// See the NOTICE file distributed with this work for additional information
+// regarding copyright ownership.  rubicon licenses this file to you under 
+// the Apache License, Version 2.0 (the "License"); you may not use this 
+// file except in compliance with the License.  You may obtain a copy of the 
+// License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software 
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT 
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the 
+// License for the specific language governing permissions and limitations
+// under the License.
+// 
+using System;
+
+namespace Remotion.Linq.UnitTests.TestDomain
+{
+  public class Result<T>
+  {
+    public Result ()
+    {
+    }
+
+    public T Value { get; set; }
+  }
+}

--- a/UnitTests/UnitTests.csproj
+++ b/UnitTests/UnitTests.csproj
@@ -150,6 +150,7 @@
     <Compile Include="App_Packages\Remotion.Utilities.NullableTypeUtility.Sources.1.15.23.0\NullableTypeUtility.cs" />
     <Compile Include="Clauses\Expressions\SubQueryExpressionTest.cs" />
     <Compile Include="Clauses\Expressions\VBStringComparisonExpressionTest.cs" />
+    <Compile Include="Clauses\ExpressionTreeVisitors\IntegrationTests\AccessorFindingExpressionTreeVisitorIntegrationTest.cs" />
     <Compile Include="Clauses\ResultOperators\ConcatResultOperatorTest.cs" />
     <Compile Include="Parsing\ExpressionTreeVisitors\MultiReplacingExpressionTreeVisitorTest.cs" />
     <Compile Include="Clauses\Expressions\PartialEvaluationExceptionExpressionTest.cs" />
@@ -194,10 +195,13 @@
     <Compile Include="Parsing\Structure\NodeTypeProviders\MethodInfoBasedNodeTypeRegistryTests\TestDomain\GenericClass2.cs" />
     <Compile Include="Parsing\TestThrowingConstantExpressionTreeVisitor.cs" />
     <Compile Include="Parsing\TupleExpressionBuilderTest.cs" />
+    <Compile Include="TestDomain\BaseValue.cs" />
     <Compile Include="TestDomain\Course.cs" />
+    <Compile Include="TestDomain\DerivedValue.cs" />
     <Compile Include="TestDomain\Knife.cs" />
     <Compile Include="TestDomain\ISpecificCook.cs" />
     <Compile Include="TestDomain\MetaID.cs" />
+    <Compile Include="TestDomain\Result.cs" />
     <Compile Include="TestUtilities\NonTransformedTuple.cs" />
     <Compile Include="Clauses\AdditionalFromClauseTest.cs" />
     <Compile Include="Clauses\Expressions\ExtensionExpressionIntegrationTest.cs" />


### PR DESCRIPTION
Notes: 
- There is no obvious way to construct a unit test that verifies the Assertion in EnsureMemberIsAccessibleFromInput. Basically, the expression tree can only contain valid constructs in this case.
- The integration test for the NewExpression can only be written using C# anonymous types due to the required member-infos in the NewExpression-ctor.
