### PR TITLE
RMLNQ-107 Don't use Enum.IsDefined in EvaluatableTreeFindingExpressionVisitor.

### DIFF
--- a/UnitTests/Parsing/ExpressionVisitors/TreeEvaluation/EvaluatableTreeFindingExpressionVisitorTest.cs
+++ b/UnitTests/Parsing/ExpressionVisitors/TreeEvaluation/EvaluatableTreeFindingExpressionVisitorTest.cs
@@ -75,6 +75,22 @@ namespace Remotion.Linq.UnitTests.Parsing.ExpressionVisitors.TreeEvaluation
     }
 
     [Test]
+    public void ExpressionTypeEnum_HasNoHoles ()
+    {
+      // We made a perf-optimization in RMLNQ-107 by avoiding calling Enum.IsDefined.
+      // This test verifies our assumption that the ExpressionType enum does not have holes.
+
+      var expected = ExpressionType.Add;
+
+      foreach (ExpressionType value in Enum.GetValues (typeof (ExpressionType)))
+      {
+          Assert.That (value, Is.EqualTo (expected), "Unexpected hole found in ExpressionType enum!");
+
+          expected++;
+      }
+    }
+
+    [Test]
     public void NestedExpression_InnerAndOuterAreEvaluatable ()
     {
       var innerExpressionLeft = Expression.Constant (0);


### PR DESCRIPTION
Identified as a hot-path during EF Core profiling. We move to a simple bounds check against the min and max values of ExpressionType.