### PR TITLE
fix IQueryExecutor Interface to have [Where T: class] constraint.

### DIFF
--- a/Core.Net_4_5/Core.Net_4_5.csproj
+++ b/Core.Net_4_5/Core.Net_4_5.csproj
@@ -40,7 +40,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
+    <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>..\remotion.snk</AssemblyOriginatorKeyFile>

--- a/Core/Clauses/StreamedData/StreamedScalarValueInfo.cs
+++ b/Core/Clauses/StreamedData/StreamedScalarValueInfo.cs
@@ -57,8 +57,8 @@ namespace Remotion.Linq.Clauses.StreamedData
       return new StreamedScalarValueInfo (dataType);
     }
 
-    public object ExecuteScalarQueryModel<T> (QueryModel queryModel, IQueryExecutor executor)
-    {
+    public object ExecuteScalarQueryModel<T> (QueryModel queryModel, IQueryExecutor executor) where T : class
+        {
       ArgumentUtility.CheckNotNull ("queryModel", queryModel);
       ArgumentUtility.CheckNotNull ("executor", executor);
 

--- a/Core/Clauses/StreamedData/StreamedSequenceInfo.cs
+++ b/Core/Clauses/StreamedData/StreamedSequenceInfo.cs
@@ -134,8 +134,8 @@ namespace Remotion.Linq.Clauses.StreamedData
       return new StreamedSequence (result, new StreamedSequenceInfo (result.GetType(), ItemExpression));
     }
 
-    public IEnumerable ExecuteCollectionQueryModel<T> (QueryModel queryModel, IQueryExecutor executor)
-    {
+    public IEnumerable ExecuteCollectionQueryModel<T> (QueryModel queryModel, IQueryExecutor executor) where T : class
+        {
       ArgumentUtility.CheckNotNull ("queryModel", queryModel);
       ArgumentUtility.CheckNotNull ("executor", executor);
 

--- a/Core/Clauses/StreamedData/StreamedSingleValueInfo.cs
+++ b/Core/Clauses/StreamedData/StreamedSingleValueInfo.cs
@@ -62,8 +62,8 @@ namespace Remotion.Linq.Clauses.StreamedData
       return new StreamedSingleValueInfo (dataType, _returnDefaultWhenEmpty);
     }
 
-    public object ExecuteSingleQueryModel<T> (QueryModel queryModel, IQueryExecutor executor)
-    {
+    public object ExecuteSingleQueryModel<T> (QueryModel queryModel, IQueryExecutor executor) where T : class
+        {
       ArgumentUtility.CheckNotNull ("queryModel", queryModel);
       ArgumentUtility.CheckNotNull ("executor", executor);
 

--- a/Core/IQueryExecutor.cs
+++ b/Core/IQueryExecutor.cs
@@ -41,7 +41,7 @@ namespace Remotion.Linq
     /// calculated or aggregated from all the values in the collection result set. This applies to, for example, item counts, average calculations,
     /// checks for the existence of a specific item, and so on.
     /// </remarks>
-    T ExecuteScalar<T> (QueryModel queryModel);
+    T ExecuteScalar<T> (QueryModel queryModel) where T : class;
 
     /// <summary>
     /// Executes the given <paramref name="queryModel"/> as a single object query, i.e. as a query returning a single object of type 
@@ -61,7 +61,7 @@ namespace Remotion.Linq
     /// calculated or aggregated from all the values in the collection result set. This applies to, for example, item counts, average calculations,
     /// checks for the existence of a specific item, and so on.
     /// </remarks>
-    T ExecuteSingle<T> (QueryModel queryModel, bool returnDefaultWhenEmpty);
+    T ExecuteSingle<T> (QueryModel queryModel, bool returnDefaultWhenEmpty) where T : class;
 
     /// <summary>
     /// Executes the given <paramref name="queryModel"/> as a collection query, i.e. as a query returning objects of type <typeparamref name="T"/>. 
@@ -73,6 +73,6 @@ namespace Remotion.Linq
     /// <param name="queryModel">The <see cref="QueryModel"/> representing the query to be executed. Analyze this via an 
     /// <see cref="IQueryModelVisitor"/>.</param>
     /// <returns>A scalar value of type <typeparamref name="T"/> that represents the query's result.</returns>
-    IEnumerable<T> ExecuteCollection<T> (QueryModel queryModel);
+    IEnumerable<T> ExecuteCollection<T> (QueryModel queryModel) where T: class;
   }
 }

--- a/Relinq.sln.DotSettings
+++ b/Relinq.sln.DotSettings
@@ -40,6 +40,8 @@
 	
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_CONSTRUCTOR_INITIALIZER_ON_SAME_LINE/@EntryValue">False</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_FIELD_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_SIMPLE_EMBEDDED_STATEMENT_ON_SAME_LINE/@EntryValue">NEVER</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SIMPLE_EMBEDDED_STATEMENT_STYLE/@EntryValue">LINE_BREAK</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_AROUND_MULTIPLICATIVE_OP/@EntryValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/SPACE_BEFORE_EMPTY_METHOD_PARENTHESES/@EntryValue">True</s:Boolean>
@@ -145,7 +147,11 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=NAMESPACE_005FALIAS/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FFIELD/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/XamlNaming/UserRules/=XAML_005FRESOURCE/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAddAccessorOwnerDeclarationBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002ECSharpPlaceAttributeOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateThisQualifierSettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002EJavaScript_002ECodeStyle_002ESettingsUpgrade_002EJsCodeFormatterSettingsUpgrader/@EntryIndexedValue">True</s:Boolean>


### PR DESCRIPTION

![genericconstraintissue](https://user-images.githubusercontent.com/73307/51885371-1ef5d680-2359-11e9-92f0-e9f0f0a2a902.png)

==> you need a generic constraint, if you want to call a generic function in the inherited class.  (the error you get is [T must be a refernce type] when you try to call a generic function inside of the   IEnumerable<T> ExecuteCollection<T>(QueryModel queryModel)  function.